### PR TITLE
Target - inherits from mbed armcc ~0.1.0

### DIFF
--- a/target.json
+++ b/target.json
@@ -9,7 +9,7 @@
     }
   ],
   "inherits": {
-    "mbed-armcc": "~0.0.0"
+    "mbed-armcc": "~0.1.0"
   },
   "keywords": [
     "mbed-target:k64f",


### PR DESCRIPTION
This fixes problem for new upcoming mbed-hal pins config

@autopulated 
