### PR TITLE
Toolchain - use soft float for now

### DIFF
--- a/CMake/toolchain.cmake
+++ b/CMake/toolchain.cmake
@@ -14,7 +14,8 @@ set(TARGET_FRDM_K64F_ARMCC_TOOLCHAIN_INCLUDED 1)
 add_definitions("-DCPU_MK64FN1M0VMD12 -DTARGET_K64F")
 
 # append non-generic flags, and set K64F-specific link script
-set(_CPU_COMPILATION_OPTIONS "--CPU=Cortex-M4.fp -D__thumb2__")
+# no fpu specified for this target, will be revised once uvisor gets FPU support
+set(_CPU_COMPILATION_OPTIONS "--CPU=Cortex-M4 -D__thumb2__")
 
 set(CMAKE_C_FLAGS_INIT             "${CMAKE_C_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS}")
 set(CMAKE_ASM_FLAGS_INIT           "${CMAKE_ASM_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS}")


### PR DESCRIPTION
gcc part is set to cortex-m4 only as well.

@AlessandroA 