### PR TITLE
remove chip-level description, instead inherit it from kinetis-k64-armcc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.0
  * derive from new
-   [kinetis-k64-gcc](https://github.com/ARMmbed/target-kinetis-k64-armcc) target
+   [kinetis-k64-armcc](https://github.com/ARMmbed/target-kinetis-k64-armcc) target
    description: most of the toolchain description now lives there, with this
    target description defining only the pinout and other board-specific
    definitions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.0
+ * derive from new
+   [kinetis-k64-gcc](https://github.com/ARMmbed/target-kinetis-k64-armcc) target
+   description: most of the toolchain description now lives there, with this
+   target description defining only the pinout and other board-specific
+   definitions.
+
 ## 0.1.5
  * add `mbed` keyword for easier discovery.
 

--- a/CMake/toolchain.cmake
+++ b/CMake/toolchain.cmake
@@ -11,14 +11,5 @@ set(TARGET_FRDM_K64F_ARMCC_TOOLCHAIN_INCLUDED 1)
 # definition that you're about to add to rely on the TARGET_LIKE_XXX
 # definitions that yotta provides based on the target.json file.
 #
-add_definitions("-DCPU_MK64FN1M0VMD12 -DTARGET_K64F")
+add_definitions("-DTARGET_K64F")
 
-# append non-generic flags, and set K64F-specific link script
-# no fpu specified for this target, will be revised once uvisor gets FPU support
-set(_CPU_COMPILATION_OPTIONS "--CPU=Cortex-M4 -D__thumb2__")
-
-set(CMAKE_C_FLAGS_INIT             "${CMAKE_C_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS}")
-set(CMAKE_ASM_FLAGS_INIT           "${CMAKE_ASM_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS}")
-set(CMAKE_CXX_FLAGS_INIT           "${CMAKE_CXX_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS}")
-#set(CMAKE_MODULE_LINKER_FLAGS_INIT "${CMAKE_MODULE_LINKER_FLAGS_INIT}")
-set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} --scatter ${CMAKE_CURRENT_LIST_DIR}/../ld/MK64F.sct") 

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,10 @@ using the ARMCC v5 compiler.
 ![k64f image](https://mbed-media.s3.amazonaws.com/k64f_image_v1.JPG.250x250_q85.jpg)
 
 This target description derives from the generic
-[mbed-armcc](https://github.com/ARMmbed/target-mbed-armcc) target description,
-which provides most of the information about how to run the compiler.
+[kinetis-k64-gcc](https://github.com/ARMmbed/target-kinetis-k64-armcc) target
+description, which provides most of the information about how to compile for
+the Mk64Fn1M0Vll12 chip used on this board.
 
+If you are creating your own board based on the Mk64Fn1M0Vll12 chip, you should
+copy this target description to use as a starting point, updating the pin
+definitions in target.json as necessary.

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ using the ARMCC v5 compiler.
 ![k64f image](https://mbed-media.s3.amazonaws.com/k64f_image_v1.JPG.250x250_q85.jpg)
 
 This target description derives from the generic
-[kinetis-k64-gcc](https://github.com/ARMmbed/target-kinetis-k64-armcc) target
+[kinetis-k64-armcc](https://github.com/ARMmbed/target-kinetis-k64-armcc) target
 description, which provides most of the information about how to compile for
 the Mk64Fn1M0Vll12 chip used on this board.
 

--- a/target.json
+++ b/target.json
@@ -2,7 +2,7 @@
   "name": "frdm-k64f-armcc",
   "version": "1.0.0",
   "inherits": {
-    "mbed-kinetis-k64-armcc": "^1.0.0"
+    "kinetis-k64-armcc": "^1.0.0"
   },
   "description": "Official mbed build target for the mbed frdm-k64f development board, using the armcc toolchain.",
   "licenses": [

--- a/target.json
+++ b/target.json
@@ -1,6 +1,9 @@
 {
   "name": "frdm-k64f-armcc",
   "version": "0.1.5",
+  "inherits": {
+    "mbed-kinetis-k64-armcc": "^1.0.0"
+  },
   "description": "Official mbed build target for the mbed frdm-k64f development board, using the armcc toolchain.",
   "licenses": [
     {
@@ -8,9 +11,6 @@
       "type": "Apache-2.0"
     }
   ],
-  "inherits": {
-    "mbed-armcc": "~0.1.0"
-  },
   "keywords": [
     "mbed-target:k64f",
     "mbed-official",
@@ -25,14 +25,6 @@
         "stacks": {
           "lwip": true
         }
-      }
-    },
-    "cmsis": {
-      "nvic": {
-        "ram_vector_address": "0x1FFF0000",
-        "flash_vector_address": "0x0",
-        "user_irq_offset": 16,
-        "user_irq_number": 86
       }
     },
     "hardware": {
@@ -94,14 +86,6 @@
   },
   "similarTo": [
     "frdm-k64f",
-    "k64f",
-    "ksdk-mcu",
-    "mk64fn1m0vmd12",
-    "mk64fn1m0",
-    "mk64fn",
-    "freescale",
-    "cortex-m4",
-    "armv7-m",
     "lwip",
     "lwip-k64f",
     "eth-k64f"

--- a/target.json
+++ b/target.json
@@ -1,6 +1,6 @@
 {
   "name": "frdm-k64f-armcc",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "inherits": {
     "mbed-kinetis-k64-armcc": "^1.0.0"
   },


### PR DESCRIPTION
armcc version of https://github.com/ARMmbed/target-frdm-k64f-gcc/pull/21

@0xc0170 @bogdanm 
